### PR TITLE
'name' and 'value' are required for setHeader().

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,9 +24,10 @@ module.exports = function(host, port) {
     opts['stream-channels'] = true;
     var query = qs.stringify(opts);
 
+    var contentType = 'application/json';
     if(files) {
       var boundary = randomString();
-      var contentType = 'multipart/form-data; boundary=' + boundary;
+      contentType = 'multipart/form-data; boundary=' + boundary;
     }
 
     if(typeof buffer === 'function') {


### PR DESCRIPTION
As of node v0.12.0 (and v0.11.x), the http client uses `setHeader` on
each header key, this means if we have a key with an `undefined` or
`null` value it will try to set the header value, and not just skip it,
or use the default.

This update defaults us to `application/json`.