### PR TITLE
Remove json type from code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ curl 'http://localhost:5001/api/v0/add?stream-cannels=true' \
 ```
 
 **Response**
-```json
+```
 [{
     Hash: string,
     Name: string
@@ -146,7 +146,7 @@ curl 'http://localhost:5001/api/v0/object/get?arg=QmYEqnfCZp7a39Gxrgyv3qRS4MoCTG
 ```
 
 **Response**
-```json
+```
 {
     Links: [{
         Name: string,


### PR DESCRIPTION
These code blocks are not literally json, so they get "invalid"-ish syntax highlighting, eg on the npm site & github.