### PR TITLE
Update the ipfsd-ctl package 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - "0.12"
   - "0.10"
-  - "0.8"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "Travis Person <travis.person@gmail.com>"
   ],
   "devDependencies": {
-    "ipfsd-ctl": "0.1.7",
+    "ipfsd-ctl": "0.2.3",
     "mocha": "^2.2.5",
     "pre-commit": "^1.0.6",
     "standard": "^3.3.2"


### PR DESCRIPTION
This updates the `ipfsd-ctl` package to make it use the shipped go-ipfs binary instead of looking for a local install.

Closes #24 after merge.