### PR TITLE
Make brfs a non-dev-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "multiaddr": "^0.1.2",
     "multipart-stream": "^1.0.0",
-    "vinyl": "^0.5.1"
+    "vinyl": "^0.5.1",
+    "brfs": "^1.4.0"
   },
   "browserify": {
     "transform": [
@@ -22,7 +23,6 @@
     "Jeromy Jonson <why@ipfs.io>"
   ],
   "devDependencies": {
-    "brfs": "^1.4.0",
     "browserify": "^11.0.0",
     "ipfsd-ctl": "0.3.0",
     "mocha": "^2.2.5",


### PR DESCRIPTION
Otherwise:

webui/apps/connections$ browserify -t reactify index.jsx
Error: Cannot find module 'brfs' from '/home/krl/unison/work/ipfs/webui/apps/connections/node_modules/ipfs-web-app/node_modules/ipfs-api'