### PR TITLE
autoconfigure in browser

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ function IpfsAPI (host_or_multiaddr, port) {
     window && window.location) {
     var split = window.location.host.split(':')
     config.host = split[0]
-    config.port = split[1] || 80
+    config.port = split[1]
   }
 
   // -- Internal

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,14 @@ function IpfsAPI (host_or_multiaddr, port) {
     config.port = port || config.port
   }
 
+  // autoconfigure in browser
+  if (!config.host &&
+    window && window.location) {
+    var split = window.location.host.split(':')
+    config.host = split[0]
+    config.port = split[1] || 80
+  }
+
   // -- Internal
 
   function command (name) {


### PR DESCRIPTION
If host is unset, and we're in the browser, use the window.location.host to auto-configure the api.