### PR TITLE
expose Buffer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -197,6 +197,8 @@ function IpfsAPI (host_or_multiaddr, port) {
     resolve: argCommand('name/resolve')
   }
 
+  self.Buffer = Buffer
+
   self.refs = argCommand('refs')
   self.refs.local = command('refs/local')
 


### PR DESCRIPTION
In order to make add work in the browser with the standalone browser, we need to access the Buffer object, it seems importing the browser-buffer as standalone trips up vinyl somehow.

This is not ideal, but unless we can find a way to make adding files from buffers really portable, it seems ok.

The three cases are:

* node, just works
* browserify, works
* standalone module in browser, not without exposing browserifys Buffer