### PR TITLE
Correctly detect browser vs node environment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ function IpfsAPI (host_or_multiaddr, port) {
 
   // autoconfigure in browser
   if (!config.host &&
-    window && window.location) {
+    typeof window !== 'undefined') {
     var split = window.location.host.split(':')
     config.host = split[0]
     config.port = split[1]


### PR DESCRIPTION
Change conditional to not try to access the `window` object (which throws error when `window` doesn't exist), instead we check the `typeof` so it doesn't crash if `window` is not defined.

We can also safely assume that `window.location` exists if `window` exists.

This closes issue #62