### PR TITLE
Add go-ipfs and ipfsd-ctl to fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,6 @@
   "main": "src/index.js",
   "dependencies": {
     "brfs": "^1.4.0",
-    "go-ipfs": "^0.3.7",
-    "ipfsd-ctl": "^0.5.0",
     "merge-stream": "^1.0.0",
     "multiaddr": "^1.0.0",
     "multipart-stream": "^2.0.0",
@@ -28,7 +26,8 @@
   },
   "devDependencies": {
     "browserify": "^11.0.0",
-    "ipfsd-ctl": "^0.3.3",
+    "go-ipfs": "^0.3.7",
+    "ipfsd-ctl": "^0.5.0",
     "mocha": "^2.2.5",
     "pre-commit": "^1.0.6",
     "standard": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "main": "src/index.js",
   "dependencies": {
     "brfs": "^1.4.0",
+    "go-ipfs": "^0.3.7",
+    "ipfsd-ctl": "^0.5.0",
     "merge-stream": "^1.0.0",
     "multiaddr": "^1.0.0",
     "multipart-stream": "^2.0.0",


### PR DESCRIPTION
Tests were broken due to change in `node-ipfsd-ctl`. This PR fixes that issue by setting `go-ipfs` as a direct dependency.

See this issue: https://github.com/ipfs/node-ipfsd-ctl/issues/20